### PR TITLE
Fixed deleting testing_steps

### DIFF
--- a/app/controllers/testing_steps_controller.rb
+++ b/app/controllers/testing_steps_controller.rb
@@ -65,14 +65,14 @@ class TestingStepsController < ApplicationController
 
   def destroy
     testing_step = TestingStep.find(params[:id])
-    issue = testing_step.issue
+    @issue = testing_step.issue
 
     update_custom_field(false)
 
     testing_step.destroy
 
     flash[:notice] = l(:notice_successful_delete)
-    redirect_to issue
+    redirect_to @issue
   end
 
   def generate


### PR DESCRIPTION
Aparently noone tried to delete release notes / testing steps since the plugin was created (1 and a half years). Otherwise they would have found this problem :D
